### PR TITLE
[Insult] Remove `aiohttp` requirement

### DIFF
--- a/insult/info.json
+++ b/insult/info.json
@@ -3,6 +3,5 @@
   "description": "Usage: [p]insult <user>\n",
   "short": "Insult a user creatively.",
   "name": "Insult",
-  "tags": ["fun"],
-  "requirements": ["aiohttp"]
+  "tags": ["fun"]
 }


### PR DESCRIPTION
`aiohttp` is already a requirement of Red and specifying it in cog requirements may cause issues.